### PR TITLE
Recalculate fullflash and bruteforce ESN support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ configure_file("src/config.h.in" "config.h" @ONLY)
 
 add_subdirectory(third_party/argparse)
 
-add_executable(emu src/main.cpp src/utils.cpp)
+add_executable(emu src/main.cpp src/utils.cpp src/siemens_recalc.cpp)
 set_target_properties(emu PROPERTIES OUTPUT_NAME "pmb887x-emu")
 target_include_directories(emu PRIVATE "${CMAKE_BINARY_DIR}")
 install(TARGETS emu RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can also use `./build/pmb887x-emu` instead of `pmb887x-emu` if you want to r
 
 # Usage
 ```
-Usage: pmb887x-emu [--help] [--version] --device VAR --fullflash VAR [--rw] [--flash-otp0 VAR] [--flash-otp1 VAR] [--flash-otp0-file VAR] [--flash-otp1-file VAR] [--flash-efa-file VAR] [--siemens-esn VAR] [--siemens-imei VAR] [--sim VAR] [--sim-reader-name VAR] [--sim-imsi VAR] [--sim-operator VAR] [--startup VAR] [--serial VAR] [--usartd] [--wait-for-serial] [--gdb] [--trace VAR] [--trace-io VAR] [--trace-log VAR] [--qemu-monitor VAR] [--qemu-run-with-gdb] [--qemu-stop-on-exception] [--qemu-debug VAR]
+Usage: pmb887x-emu [--help] [--version] --device VAR --fullflash VAR [--rw] [--flash-otp0 VAR] [--flash-otp1 VAR] [--flash-otp0-file VAR] [--flash-otp1-file VAR] [--flash-efa-file VAR] [--siemens-esn VAR] [--siemens-imei VAR] [--siemens-recover-esn] [--siemens-no-recalc] [--sim VAR] [--sim-reader-name VAR] [--sim-imsi VAR] [--sim-operator VAR] [--startup VAR] [--serial VAR] [--usartd] [--wait-for-serial] [--gdb] [--trace VAR] [--trace-io VAR] [--trace-log VAR] [--qemu-monitor VAR] [--qemu-run-with-gdb] [--qemu-stop-on-exception] [--qemu-debug VAR]
 
 Generic emulator for PMB887X-based mobile phones.
 
@@ -45,6 +45,8 @@ OTP options (detailed usage):
   --flash-efa-file              Raw NOR flash EFA file [nargs=0..1] [default: ""]
   --siemens-esn                 Siemens flash ESN (HEX) [nargs=0..1] [default: ""]
   --siemens-imei                Siemens flash IMEI (number) [nargs=0..1] [default: ""]
+  --siemens-recover-esn         Recover the original ESN of the fullflash by brute force instead of recalculating its keys 
+  --siemens-no-recalc           Do not recalculate the fullflash security keys in memory for the emulator IMEI/ESN 
 
 SIM options (detailed usage):
   --sim                         SIM source: virtual, none, or reader [nargs=0..1] [default: "virtual"]
@@ -100,23 +102,26 @@ Files are created on the first successful data change. A missing or empty file u
 Use `--flash-N-otp0-file`, `--flash-N-otp1-file` and `--flash-N-efa-file` to override paths for banks 0-3. FLASH0 also accepts the names without `-0`. Passing a file for an unsupported region is an error.
 
 # Real world example
-Let's assume you have a fullflash. Of course, simply running commands from the examples won't work. :)
+Let's assume you have a fullflash. Siemens mobile devices are paranoid and the firmware has hardware binding:
+the keys stored in the fullflash must match the ESN and IMEI of the phone.
 
-That's because Siemens mobile devices are paranoid and the firmware has hardware binding.
+The emulator handles this for you: on every start of a Siemens board it recalculates the keys for the emulator
+ESN/IMEI **in memory** (the fullflash file is not modified), so this simply works:
+```
+pmb887x-emu --fullflash EL71.bin --device siemens-el71
+```
 
-You have two options:
+Alternatively `--siemens-recover-esn` searches for the original ESN of the fullflash and runs it untouched.
+The result is saved next to the fullflash as a `.esn` file, and while that file matches, the recovered ESN is used
+automatically on the next runs without `--siemens-recover-esn`.
 
-1. Recalculate keys in the firmware using the following steps: [docs/recalc-siemens-fullflash.md](docs/recalc-siemens-fullflash.md)
-   
-   Then run the emulator like this:
-   ```
-   pmb887x-emu --fullflash EL71.bin --device siemens-el71
-   ```
+Details and how to disable the recalculation (`--siemens-no-recalc`): [docs/recalc-siemens-fullflash.md](docs/recalc-siemens-fullflash.md).
+The algorithm itself is described in [docs/recalc-alogrithm.md](docs/recalc-alogrithm.md).
 
-2. Find the original ESN and IMEI from your phone and run the emulator like this:
-   ```
-   pmb887x-emu --fullflash EL71.bin --device siemens-el71 --siemens-esn=12345678 --siemens-imei=490154203237518
-   ```
+If you know the original ESN and IMEI of your phone, you can run the emulator with them and nothing needs to be recalculated:
+```
+pmb887x-emu --fullflash EL71.bin --device siemens-el71 --siemens-esn=12345678 --siemens-imei=490154203237518
+```
 
 LG phones do not need ESN/IMEI, but they need a provisioned EFA region to work correctly (though not strictly required to boot) - commonly seen as separate 32K `.eep` image (unencrypted, a valid one should begin with `FF` bytes and contain model/version info around 0x72A0) or appended as 32K tail at the end of a `.bin` dump.
 

--- a/docs/recalc-alogrithm.md
+++ b/docs/recalc-alogrithm.md
@@ -1,0 +1,237 @@
+# Siemens fullflash key recalculation algorithm
+
+This document describes what "Recalc Fullflash" in **x65PapuaUtils v1.1.1c** (by a1ex) actually
+does to a fullflash. The algorithm was 
+re-implemented in `src/siemens_recalc.cpp`. The emulator applies it in memory on every start
+(see [recalc-siemens-fullflash.md](recalc-siemens-fullflash.md)), so a stock fullflash can be
+used without preparing it first.
+
+The implementation was verified against fullflashes recalculated by the original tool:
+for the same IMEI / ESN / SKEY the output is byte-identical (S75 x75, EL71 x85).
+
+All multi-byte integers below are little-endian.
+
+## 1. Inputs
+
+| Input | Meaning | Emulator default |
+|-------|---------|------------------|
+| IMEI  | 15 decimal digits | `490154203237518` (`--siemens-imei`) |
+| ESN   | 32-bit NOR flash serial number, given as 8 hex digits | `12345678` (`--siemens-esn`) |
+| SKEY  | "service key", up to 8 **decimal** digits, used as a 32-bit integer | `12345678` (fixed) |
+| Master codes | six 32-bit integers, the phone master codes | `12345678` each (PapuaUtils default) |
+| VerDown | one byte stored in EEPROM block 52, the "VerDown" setting of PapuaUtils | `1` |
+
+Note that ESN is parsed as **hex** (`$12345678`) while SKEY is parsed as **decimal**
+(`12345678` = `0x00BC614E`).
+
+## 2. Key derivation: BootKey (BKEY) and HASH
+
+```
+block[0..3]  = ESN  (u32 LE)
+block[4..7]  = SKEY (u32 LE)
+for i in 0..7:
+    block[8+i] = block[i] ^ block[i+3]      # computed in place, so bytes 13..15 use the new bytes 8..10
+BKEY = MD5(block)          # 16 bytes
+HASH = MD5(BKEY)           # 16 bytes
+```
+
+PapuaUtils does this with a single hand-padded MD5 transform, which is equivalent to a normal
+MD5 of the 16-byte message.
+
+Example: ESN `12345678`, SKEY `12345678` gives
+BKEY `2062670E09537A7FE079462A0EC98168`, HASH `54F80AC12ACD94B2F5CFFB9BF7E4D493`.
+
+## 3. Fullflash layout detection
+
+The file must be 32, 64 or 96 MB. Two generations exist:
+
+| | x65 / x75 (SGold) | x85 (SGold2: EL71, E71, M81, S68, C81, ...) |
+|---|---|---|
+| Detection | otherwise | `u32 @ 0x1200 == 0x534C0300` (bytes `00 03 4C 53`) |
+| Erase block size | 0x20000 | 0x40000 |
+| Block signature offset | 0 | 0x3FFE0 (end of the block) |
+| EEPROM header stride | 0x10 | 0x20 |
+
+The tool walks the file in erase blocks and classifies each block by the 4 bytes at the
+signature offset:
+
+| Signature | Block type |
+|-----------|------------|
+| `E5 1F F0 E5` (ARM `ldr pc`) or `FF FF FF FF` in block 0 | BCORE (bootcore) |
+| `EELI` (`EELITE`) | EEPROM LITE |
+| `EEFU` (`EEFULL`) | EEPROM FULL (always two consecutive blocks) |
+| `FFS\0`, `FFS_0/1/2`, `FFS_B/C` | file system (not touched) |
+| `BB BB 00 00` | EXIT (not touched) |
+
+Typical layout: BCORE at 0, EELITE at 0x40000, EEFULL in the last blocks of the flash.
+
+## 4. Bootcore patch
+
+Two values are replaced in block 0:
+
+| Layout | HASH (16 bytes) | IMEI (15 ASCII digits) |
+|--------|-----------------|------------------------|
+| x85 | 0x3E400 | 0x3E410 |
+| x65/x75, `byte @ 0x200 == 2` | 0x23C | 0x660 |
+| x65/x75, other bootcore version | 0x238 | 0x65C |
+
+If the HASH location (or, on x65/x75, the words at 0x204/0x660/0xA90/0x238) reads `FFFFFFFF`
+the bootcore is "cleared" and recalculation is impossible.
+
+## 5. EEPROM structure
+
+Every EEPROM block has a table of 16-byte entry headers growing **downwards** from the top
+of the block (x65/x75: first header at 0x1FFF0, x85: at 0x3FFC0). Scanning stops when a
+header starts with `FFFFFFFF` or the offset drops to 0x2000.
+
+```
+struct header {
+    u32 flags;       // 0xFFFFFFC0 = valid entry, 0xFFFFFF00 = deleted
+    u16 id;          // block id (< 500); FULL ids are reported as id + 5000
+    u8  zero;
+    u8  unused;
+    u32 size;        // stored size (< 25000)
+    u32 data_offset; // offset of the data inside the erase block
+};
+```
+
+Where the data lives:
+
+* **x65/x75**: always at `data_offset`.
+* **x85**: small entries (FULL: size <= 0x200, LITE: size <= 0x10) are stored *inline* right
+  below the header: starting at `hdr - 0x10 - size - (size & ~0xF)`, in 16-byte pieces that
+  skip every second 16-byte slot (bytes whose block offset has bit 4 set are not data).
+  Larger entries use `data_offset`. On x85 the headers may have gaps: after a valid header
+  the next one is searched downwards in 0x20 steps (up to 0x420 bytes).
+
+Stored size vs. payload:
+
+* EEFULL entries carry one extra byte **in front** of the payload (stored size = payload + 1,
+  payload starts at `data_offset + 1`); the leading byte is left as is.
+* On x65/x75, EELITE entries carry one extra byte **after** the payload.
+* On x85, EELITE entries have no extra byte.
+
+If a matched entry has an unexpected size it is reported and left alone.
+
+## 6. Entries that get replaced
+
+`IMEI8` below is the IMEI packed into 8 bytes: `(d0 << 4) | 0x0A`, then
+`(d2 << 4) | d1`, `(d4 << 4) | d3`, ... `(d12 << 4) | d11`, `d13` (digit 14 is unused).
+
+| Entry | Size | Content | Mandatory |
+|-------|------|---------|-----------|
+| LITE 76 | 10 | IMEI block, variant 0 (see 7.1) | yes |
+| FULL 8 (5008) | 0xE0 | encrypted record (see 7.3) | yes |
+| FULL 9 (5009) | 10 | IMEI block, variant 1 (see 7.1) | yes |
+| FULL 77 (5077) | 0xE8 | encrypted record (see 7.3) | yes |
+| FULL 121 (5121) | 0x38 | encrypted SKEY marker + 6 encrypted master codes (see 7.4) | yes |
+| FULL 122 (5122) | 6 | `SKEY (u32)`, `58 00` | yes |
+| FULL 123 (5123) | 0xC or 0x20 | `3F FF FF FF` + first 8 bytes of block 121 (12-byte variant, x75/x85); `07 1F FF FF` + the same for the 0x20 variant of older x65 firmware (the remaining bytes are not changed) | yes |
+| LITE 52 | 0x122 | `BKEY (16)`, `VerDown (1)`, then a constant 145-byte tail starting `FF 01 00 00 01 03 00 01 00 01 00 54 00 55 00 80 00 D9 D9 F3 ...` and `FF` padding (see `BLOCK52_TAIL` in the source) | yes |
+| FULL 468 (5468) | 0x31 | `BKEY (16)`, `58`, `MD5(ESN u32)` (16), `MD5(IMEI ASCII)[0..8]`, `MD5(previous 0x29 bytes)[0..8]` | no (x85 only) |
+| LITE 320 | 0x10 | `BKEY` | no (x85 only) |
+
+PapuaUtils refuses the result if any mandatory entry was not found. Entries whose current
+content already equals the generated one are reported as "does not require replacement".
+
+## 7. Building blocks
+
+### 7.1 IMEI block (LITE 76 / FULL 9)
+
+```
+buf[0..6] = 14 IMEI digits as BCD, low nibble = even digit, high nibble = odd digit
+buf[7]    = luhn_check_digit(digits 0..13) << 4      # recomputed, digit 14 of the IMEI is ignored
+xe = buf[0] ^ buf[2] ^ buf[4] ^ buf[6]
+xo = buf[1] ^ buf[3] ^ buf[5] ^ buf[7]
+buf[8] = xe   (variant 0)   |   xo   (variant 1)
+buf[9] = xe ^ xo ^ 0xFF
+rounds: variant 0 uses round keys K[1], K[3], K[5], K[7]; variant 1 uses K[0], K[2], K[4], K[6]
+        K = E3 B7 5C 13 B0 D2 C4 19
+each round:
+    mask = 0
+    for k in 0..4:
+        old    = buf[k]
+        s      = (SBOX_HI[old >> 4] << 4) + SBOX_LO[old & 0xF]
+        buf[k] = s ^ K[r] ^ buf[k+5] ^ mask
+        buf[k+5] = old
+        mask ^= 0xFF
+SBOX_HI = 03 0F 01 0D 05 0B 0D 09 0D 07 06 00 0E 06 0B 08
+SBOX_LO = 0A 0E 01 05 03 06 02 0F 0B 0A 03 05 06 05 04 02
+```
+
+(The tool contains three S-box pairs selected by a "phone type" argument; the fullflash
+recalculation always uses type 5, which is the pair above.)
+
+### 7.2 Stream cipher
+
+All encrypted entries use the same cipher, keyed by a 64-byte key block:
+
+```
+K  = MD4(key64)                                   # 16 bytes (MD4 with normal padding)
+S  = RC4 key schedule with K as a 16-byte key      # standard KSA
+i = j = prev = 0
+for each byte b:
+    i    = (i + 1) & 0xFF
+    prev = (prev + S[i]) & 0xFF
+    j    = (j + prev) & 0xFF
+    t    = (S[j] + prev) & 0xFF
+    S[i] = S[j]                                    # not a swap!
+    S[j] = prev
+    encrypt: prev = S[t] ^ b ; output prev
+    decrypt: prev = b        ; output S[t] ^ prev
+```
+
+Three key blocks are embedded in the tool (see `KEY_EEP`, `KEY_MK1`, `KEY_MK2` in the
+source); some words are overwritten per phone:
+
+* `KEY_EEP` (blocks 8 and 77): `[0x30] = ESN`, `[0x38..0x40] = IMEI8`.
+* `KEY_MK1(code)` (block 121): `[0] = code ^ 0x7F0BF23B`, `[4] = ESN`, `[0x38..0x40] = IMEI8`.
+* `KEY_MK2(code)` (block 121): `[0] = (IMEI8[0] << 8) + 8 + (IMEI8[1] << 16) + (IMEI8[2] << 24)`,
+  `[4..8] = IMEI8[3..7]`, `[0x38] = code ^ 0x7F0BF23B`, `[0x3C] = ESN`.
+
+### 7.3 Blocks 8 and 77
+
+Block 8 (0xE0 bytes):
+
+```
+u32 @0x00 = 0x56605650   u32 @0x04 = 0          u32 @0x08 = 0x300      u32 @0x0C = 0x670000
+u32 @0x10 = 0            u32 @0x14 = 0xFFFFFFFF u32 @0x18 = 0xFFFFFFFF u32 @0x1C = 0x6462FF00
+u32 @0x20 = 0x56805670   u32 @0x24 = 0          bytes 0x28..0xE0 = FF  u32 @0xD8 = 0x50  u32 @0xDC = 0
+@0x1E = sum8(bytes 0x08..0x1E), @0x1F = xor8(bytes 0x08..0x1E)
+@0xD8 = sum8(bytes 0x28..0xD8), @0xD9 = xor8(bytes 0x28..0xD8)
+u32 @0x00 ^= 0xBA1FE5D7, u32 @0x04 ^= 0xD95D2DFD, u32 @0x20 ^= 0xBA1FE5D7, u32 @0x24 ^= 0xD95D2DFD
+encrypt(bytes 0x00..0x20, KEY_EEP); encrypt(bytes 0x20..0xE0, KEY_EEP)     # two separate streams
+```
+
+Block 77 (0xE8 bytes):
+
+```
+u32 @0x00 = 0x56A05690, u32 @0x04 = 0, bytes 0x08..0xE8 = FF, byte @0x0B = 0
+u32 @0xE0 = 0x063DFF29, u32 @0xE4 = 0xF3800B06
+@0xE0 = sum8(bytes 0x08..0xE0), @0xE1 = xor8(bytes 0x08..0xE0)     # overwrites the two words above
+u32 @0x00 ^= 0xBA1FE5D7, u32 @0x04 ^= 0xD95D2DFD
+encrypt(all 0xE8 bytes, KEY_EEP)
+```
+
+### 7.4 Block 121 (SKEY and master codes)
+
+```
+out[0..8]  = encrypt({0x77C5742D, 0xF49A4ADA}, KEY_MK1(SKEY))
+for k in 0..5:
+    v = {k ^ 0x77C5742D, 0xF49A4ADA}
+    v = encrypt(v, KEY_MK2(master[k]))
+    v = encrypt(v, KEY_MK1(master[k]))
+    out[8 + 8k .. 16 + 8k] = v
+```
+
+## 8. What the emulator does with it
+
+`pmb887x-emu` reads the fullflash, runs the algorithm for the emulator IMEI / ESN / SKEY and,
+if anything had to change, hands QEMU an in-memory copy (`memfd` on Linux, a temporary file
+elsewhere), so the file on disk is not modified. With `--rw` the keys are written into the file
+itself. Nothing is done when the keys already match.
+
+The same relations run backwards: a fullflash stores the IMEI, the SKEY and the BootKey, so the only
+unknown in section 2 is the ESN. `--siemens-recover-esn` brute forces those 32 bits against the stored
+BootKey (or against the bootcore HASH when the BootKey is blank) and runs the fullflash unmodified with
+the ESN it finds.

--- a/docs/recalc-siemens-fullflash.md
+++ b/docs/recalc-siemens-fullflash.md
@@ -1,25 +1,46 @@
 # Why is this needed?
 Siemens Mobile is paranoid and all fullflashes have hardware binding to the NOR flash serial number.
-You need to recalculate some keys in the fullflash before running it on the emulator.
+The keys in the fullflash must match the ESN and IMEI of the (emulated) phone before it can boot.
 
-# How to do this?
-This can be done with a few simple steps:
+# Automatic recalculation
+Since the emulator knows which ESN and IMEI it presents to the firmware, it recalculates the keys
+itself: on every start of a Siemens board the fullflash is checked and, if needed, patched
+**in memory** (the file on disk is not modified unless --rw is specified).
 
-1. Download [x65PapuaUtils V1.1.1b](https://web.archive.org/web/20120711125854/http://forum.allsiemens.com/download.php?id=67331) (works fine in Wine)
+```
+pmb887x-emu --device siemens-s75 --fullflash S75.bin
+```
 
-2. Go to the "Codes" tab and enter these values:
-    - **IMEI:** 490154203237518
-    - **ESN:** 12345678
-    - **SKEY:** 12345678
-    
-    ![recalc-flash-0.png](recalc-flash-0.png)
-    
-3. Press the button "Calc HASH + BootKEY from ESN and SKEY".
+The recalculation uses the emulator IMEI/ESN (`--siemens-imei`, `--siemens-esn`) and the service key
+`12345678` (the value does not matter for the emulator, it only has to be consistent with the keys).
+The algorithm is documented in [recalc-alogrithm.md](recalc-alogrithm.md).
 
-4. Go to the "Convert" tab and press the button "Recalc Fullflash". In the opened window, select your input fullflash and output file.
-    ![recalc-flash-1.png](recalc-flash-1.png)
+Related options:
 
-5. Done! Now you can use the newly saved fullflash in the emulator.
+- `--siemens-no-recalc` disables the automatic recalculation and runs the fullflash as is.
+- With `--rw` the fullflash file is the phone's flash, so the keys are recalculated **in the file** (only
+  the affected bytes are rewritten). Use `--siemens-no-recalc` if you don't want that.
+
+# Running a fullflash without touching it
+A fullflash read from a real phone is already consistent with the ESN of that phone. Everything the
+key check needs is stored in it except the ESN itself: the IMEI and the HASH in the bootcore, the SKEY
+in EEPROM block 122 and the BootKey in EEPROM block 52.
+
+So instead of rewriting the keys for the emulator ESN, the emulator can search for the ESN they were
+built from and give that to the firmware:
+
+```
+pmb887x-emu --device siemens-s75 --fullflash S75.bin --siemens-recover-esn
+```
+
+This sweeps all 2^32 ESNs on every core (up to 30s on Ryzen 9 5950X) and then runs the fullflash with its
+original IMEI and ESN, without changing a single byte. The result is cached in `S75.bin.esn`, so only
+the first start is slow; delete that file to search again.
+
+It only works on a fullflash whose keys are intact, because there is nothing to recover from a cleared
+bootcore or an EEPROM without a SKEY. Recalculation handles those, ESN recovery does not.
+`--siemens-recover-esn` reads the identity from the fullflash, so it can't be combined with
+`--siemens-imei` or `--siemens-esn`.
 
 # Running with original ESN and IMEI
 If you know your original IMEI and ESN, you can run the emulator without key recalculation.
@@ -28,3 +49,25 @@ Example:
 ```
 pmb887x-emu --siemens-esn=12345678 --siemens-imei=490154203237518
 ```
+
+(With the original values nothing needs to be changed and the recalculation is a no-op.)
+
+# Manual recalculation with PapuaUtils
+This is what the emulator does automatically; you only need it if you want a recalculated file
+for other tools.
+
+1. Download [x65PapuaUtils V1.1.1b](https://web.archive.org/web/20120711125854/http://forum.allsiemens.com/download.php?id=67331) (works fine in Wine)
+
+2. Go to the "Codes" tab and enter these values:
+    - **IMEI:** 490154203237518
+    - **ESN:** 12345678
+    - **SKEY:** 12345678
+
+    ![recalc-flash-0.png](recalc-flash-0.png)
+
+3. Press the button "Calc HASH + BootKEY from ESN and SKEY".
+
+4. Go to the "Convert" tab and press the button "Recalc Fullflash". In the opened window, select your input fullflash and output file.
+    ![recalc-flash-1.png](recalc-flash-1.png)
+
+5. Done! Now you can use the newly saved fullflash in the emulator without recalculation or ESN bruteforce.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,11 @@
 #include <array>
 #include <cctype>
 #include <cstdint>
+#include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -13,11 +16,13 @@
 #include <vector>
 
 #include "config.h"
+#include "siemens_recalc.h"
 #include "utils.h"
 
 static std::string getBoardConfig(const std::string &device);
 static std::string getQemuBin();
 static void validateSimIdentity(const std::string &imsi, const std::string &operatorCode);
+static std::string identityKey(const SiemensIdentity &identity);
 
 struct FlashBankOptions {
 	std::string otp0;
@@ -113,6 +118,16 @@ int main(int argc, char *argv[]) {
 		.help("Siemens flash IMEI (number)")
 		.nargs(1)
 		.default_value("");
+
+	program.add_argument("--siemens-recover-esn")
+		.help("Recover the original ESN of the fullflash by brute force instead of recalculating its keys")
+		.default_value(false)
+		.implicit_value(true);
+
+	program.add_argument("--siemens-no-recalc")
+		.help("Do not recalculate the fullflash security keys in memory for the emulator IMEI/ESN")
+		.default_value(false)
+		.implicit_value(true);
 
 	program.add_group("SIM options");
 
@@ -219,6 +234,7 @@ int main(int argc, char *argv[]) {
 	auto device = program.get<std::string>("--device");
 	auto siemensEsn = program.get<std::string>("--siemens-esn");
 	auto siemensImei = program.get<std::string>("--siemens-imei");
+	const bool recoverEsn = program.get<bool>("--siemens-recover-esn");
 	auto fullflash = program.get<std::string>("--fullflash");
 	auto sim = program.get<std::string>("--sim");
 #if HAVE_SIM_READER
@@ -259,6 +275,13 @@ int main(int argc, char *argv[]) {
 			return 1;
 		}
 	}
+	if (recoverEsn && (program.is_used("--siemens-esn") || program.is_used("--siemens-imei"))) {
+		std::cerr << "--siemens-recover-esn reads the IMEI and ESN from the fullflash, "
+			<< "so it can't be combined with --siemens-esn or --siemens-imei\n";
+		return 1;
+	}
+
+	const bool siemensBoard = device.starts_with("siemens-");
 
 	qemuEnv["PMB887X_BOARD"] = getBoardConfig(device);
 	qemuEnv["PMB887X_STARTUP"] = startup;
@@ -290,16 +313,139 @@ int main(int argc, char *argv[]) {
 	}
 
 	FlashBankOptions &flash0 = flashOptions[0];
+
+	// A fullflash from a real phone is already consistent with the ESN of that phone. Instead of
+	// rewriting its keys we can search for the ESN they were built from and present that to the firmware.
+	bool esnRecovered = false;
+	// A previously recovered ESN is a better match for the fullflash than recalculated keys, so an
+	// existing cache file is used automatically unless the identity was given on the command line.
+	const bool identityGiven = program.is_used("--siemens-esn") || program.is_used("--siemens-imei") ||
+		!flash0.otp0.empty() || !flash0.otp1.empty();
+	std::error_code esnCacheEc;
+	const bool esnCached = !fullflash.empty() && std::filesystem::exists(esnCachePath(fullflash), esnCacheEc);
+	if (siemensBoard && (recoverEsn || (esnCached && !identityGiven))) {
+		if (!flash0.otp0.empty() || !flash0.otp1.empty()) {
+			std::cerr << "--siemens-recover-esn can't be combined with raw OTP data\n";
+			return 1;
+		}
+		std::vector<uint8_t> data;
+		if (!readFile(fullflash, data)) {
+			std::cerr << "Can't read fullflash: " << fullflash << "\n";
+			return 1;
+		}
+
+		SiemensIdentity identity = siemensReadIdentity(data);
+		if (!identity.ok && recoverEsn) {
+			std::cerr << "Can't read the IMEI and keys from this fullflash, so the ESN can't be recovered.\n"
+				<< "Run without --siemens-recover-esn to recalculate the keys instead.\n";
+			return 1;
+		}
+
+		uint32_t esn = 0;
+		bool haveEsn = identity.ok && readEsnCache(fullflash, identity.imei, identityKey(identity), esn);
+		if (haveEsn) {
+			std::cout << "[esn] Using ESN " << esnToHex(esn) << " cached in " << esnCachePath(fullflash) << "\n";
+		} else if (recoverEsn) {
+			std::cout << "[esn] Searching for the ESN of IMEI " << identity.imei << " (up to 2^32 keys, this can take a while)...\n";
+			std::cout.flush();
+
+			const auto started = std::chrono::steady_clock::now();
+			if (!siemensRecoverEsn(identity, esn)) {
+				std::cerr << "ESN not found, the keys in this fullflash are inconsistent.\n"
+					<< "Run without --siemens-recover-esn to recalculate them instead.\n";
+				return 1;
+			}
+
+			const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+				std::chrono::steady_clock::now() - started).count();
+			std::cout << "[esn] Recovered ESN " << esnToHex(esn) << " in " << elapsed << " s\n";
+			writeEsnCache(fullflash, identity.imei, identityKey(identity), esn);
+			haveEsn = true;
+		} else {
+			// The cache is stale (different fullflash identity), fall back to recalculation.
+			std::cout << "[esn] " << esnCachePath(fullflash) << " doesn't match this fullflash, recalculating the keys instead\n";
+		}
+
+		if (haveEsn) {
+			siemensEsn = esnToHex(esn);
+			siemensImei = identity.imei;
+			esnRecovered = true;
+		}
+	}
+
 	// Default emulator IMEI & ESN for FLASH0
-	if (device.starts_with("siemens-") && siemensEsn.empty() && flash0.otp0.empty())
+	if (siemensBoard && siemensEsn.empty() && flash0.otp0.empty())
 		siemensEsn = "12345678";
-	if (device.starts_with("siemens-") && siemensImei.empty() && flash0.otp1.empty())
+	if (siemensBoard && siemensImei.empty() && flash0.otp1.empty())
 		siemensImei = "490154203237518"; // Nokia *trollface*
 
 	if (flash0.otp0.empty() && !siemensEsn.empty())
 		flash0.otp0 = convertESNtoOTP(siemensEsn);
 	if (flash0.otp1.empty() && !siemensImei.empty())
 		flash0.otp1 = convertIMEItoOTP(siemensImei);
+
+	// Siemens firmware binds itself to the ESN/IMEI with keys stored in the bootcore and EEPROM.
+	// Recalculate them in memory for the emulator identity unless disabled.
+	const bool rw = program.get<bool>("--rw");
+	const bool recalcEnabled = siemensBoard && !esnRecovered && !program.get<bool>("--siemens-no-recalc");
+	std::string qemuFullflash = fullflash;
+	TempFileCopy fullflashCopy;
+	if (recalcEnabled) {
+		if (siemensImei.size() != 15 || siemensEsn.size() != 8) {
+			std::cout << "[recalc] IMEI or ESN is unknown (raw OTP data was given), fullflash keys are not recalculated\n";
+		} else {
+			std::vector<uint8_t> data;
+			if (!readFile(fullflash, data)) {
+				std::cerr << "Can't read fullflash: " << fullflash << "\n";
+				return 1;
+			}
+
+			SiemensKeys keys;
+			keys.imei = siemensImei;
+			keys.esn = static_cast<uint32_t>(std::stoul(siemensEsn, nullptr, 16));
+			// Only consistency matters for the emulator, so the PapuaUtils defaults are used.
+			keys.skey = 12345678;
+			keys.masterKeys.fill(12345678);
+
+			const std::vector<uint8_t> original = rw ? data : std::vector<uint8_t>();
+			SiemensRecalcResult result = siemensRecalcFullflash(data, keys);
+			for (const auto &line : result.log)
+				std::cout << "[recalc] " << line << "\n";
+
+			if (!result.structureOk) {
+				std::cout << "[recalc] Fullflash structure was not recognized, running it as is\n";
+			} else if (result.replaced == 0) {
+				std::cout << "[recalc] Fullflash keys already match IMEI " << keys.imei << " and ESN " << siemensEsn << "\n";
+			} else if (rw) {
+				// In write mode the fullflash on disk is the phone's flash, so recalculate it in place.
+				if (!patchFile(fullflash, original, data)) {
+					std::cerr << "Can't write recalculated keys to " << fullflash << "\n";
+					return 1;
+				}
+				std::cout << "[recalc] Fullflash keys recalculated in " << fullflash << " for IMEI " << keys.imei << " and ESN " << siemensEsn
+					<< (result.complete ? "" : " (some EEPROM blocks were not found)") << "\n";
+			} else {
+				if (!fullflashCopy.create(data)) {
+					std::cerr << "Can't create an in-memory copy of the fullflash\n";
+					return 1;
+				}
+				qemuFullflash = fullflashCopy.path();
+				std::cout << "[recalc] Fullflash keys recalculated in memory for IMEI " << keys.imei << " and ESN " << siemensEsn
+					<< (result.complete ? "" : " (some EEPROM blocks were not found)") << "\n";
+
+				// QEMU derives the OTP/EFA side files from the fullflash name, keep them next to the original file.
+				auto keepSideFile = [&](std::string &option, const char *suffix) {
+					std::error_code ec;
+					if (option.empty() && std::filesystem::exists(fullflash + suffix, ec))
+						option = fullflash + suffix;
+				};
+				keepSideFile(flash0.otp0File, ".cfi-otp0");
+				keepSideFile(flash0.otp1File, ".cfi-otp1");
+				keepSideFile(flash0.efaFile, ".cfi-efa");
+			}
+		}
+	}
+
 	for (size_t index = 0; index < FLASH_BANK_COUNT; index++) {
 		const FlashBankOptions &options = flashOptions[index];
 		const std::string prefix = "PMB887X_FLASH" + std::to_string(index) + "_";
@@ -327,13 +473,13 @@ int main(int argc, char *argv[]) {
 	qemuArgs.emplace_back("-machine");
 	qemuArgs.emplace_back("pmb887x");
 
-	if (program.get<bool>("--rw")) {
+	if (rw) {
 		std::cout << "Write mode enabled! Your fullflash will be modified!\n";
 		qemuArgs.emplace_back("-drive");
-		qemuArgs.emplace_back("if=pflash,format=raw,file=" + fullflash);
+		qemuArgs.emplace_back("if=pflash,format=raw,file=" + qemuFullflash);
 	} else {
 		qemuArgs.emplace_back("-drive");
-		qemuArgs.emplace_back("if=pflash,readonly=on,format=raw,file=" + fullflash);
+		qemuArgs.emplace_back("if=pflash,readonly=on,format=raw,file=" + qemuFullflash);
 	}
 
 	if (program.present("--trace"))
@@ -427,6 +573,11 @@ static std::string getBoardConfig(const std::string &device) {
 	throw std::runtime_error("QEMU configuration file not found: " + device);
 
 	return "";
+}
+
+// The cache is tied to the keys it was recovered from, so it is dropped when the fullflash changes.
+static std::string identityKey(const SiemensIdentity &identity) {
+	return identity.hasBootKey ? toHex(identity.bootKey.data(), 16) : toHex(identity.hash.data(), 16);
 }
 
 static std::string getQemuBin() {

--- a/src/siemens_recalc.cpp
+++ b/src/siemens_recalc.cpp
@@ -1,0 +1,811 @@
+#include "siemens_recalc.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <thread>
+
+namespace {
+
+constexpr uint32_t rol32(uint32_t x, unsigned n) {
+	return (x << n) | (x >> (32 - n));
+}
+
+uint32_t rd32(const uint8_t *p) {
+	return (uint32_t) p[0] | ((uint32_t) p[1] << 8) | ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+}
+
+void wr32(uint8_t *p, uint32_t v) {
+	p[0] = v & 0xFF;
+	p[1] = (v >> 8) & 0xFF;
+	p[2] = (v >> 16) & 0xFF;
+	p[3] = (v >> 24) & 0xFF;
+}
+
+uint16_t rd16(const uint8_t *p) {
+	return (uint16_t) (p[0] | (p[1] << 8));
+}
+
+/* ---------------------------------------------------------------- MD5 --- */
+
+constexpr uint32_t MD5_INIT[4] = { 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476 };
+
+#define MD5_F1(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
+#define MD5_F2(x, y, z) MD5_F1((z), (x), (y))
+#define MD5_F3(x, y, z) ((x) ^ (y) ^ (z))
+#define MD5_F4(x, y, z) ((y) ^ ((x) | ~(z)))
+#define MD5_STEP(f, a, b, c, d, x, t, s) { (a) += f((b), (c), (d)) + (x) + (t); (a) = rol32((a), (s)) + (b); }
+
+// One MD5 compression round. Unrolled because the ESN brute force runs it billions of times.
+void md5Transform(uint32_t h[4], const uint32_t M[16]) {
+	uint32_t a = h[0], b = h[1], c = h[2], d = h[3];
+
+	MD5_STEP(MD5_F1, a, b, c, d, M[0], 0xd76aa478, 7)
+	MD5_STEP(MD5_F1, d, a, b, c, M[1], 0xe8c7b756, 12)
+	MD5_STEP(MD5_F1, c, d, a, b, M[2], 0x242070db, 17)
+	MD5_STEP(MD5_F1, b, c, d, a, M[3], 0xc1bdceee, 22)
+	MD5_STEP(MD5_F1, a, b, c, d, M[4], 0xf57c0faf, 7)
+	MD5_STEP(MD5_F1, d, a, b, c, M[5], 0x4787c62a, 12)
+	MD5_STEP(MD5_F1, c, d, a, b, M[6], 0xa8304613, 17)
+	MD5_STEP(MD5_F1, b, c, d, a, M[7], 0xfd469501, 22)
+	MD5_STEP(MD5_F1, a, b, c, d, M[8], 0x698098d8, 7)
+	MD5_STEP(MD5_F1, d, a, b, c, M[9], 0x8b44f7af, 12)
+	MD5_STEP(MD5_F1, c, d, a, b, M[10], 0xffff5bb1, 17)
+	MD5_STEP(MD5_F1, b, c, d, a, M[11], 0x895cd7be, 22)
+	MD5_STEP(MD5_F1, a, b, c, d, M[12], 0x6b901122, 7)
+	MD5_STEP(MD5_F1, d, a, b, c, M[13], 0xfd987193, 12)
+	MD5_STEP(MD5_F1, c, d, a, b, M[14], 0xa679438e, 17)
+	MD5_STEP(MD5_F1, b, c, d, a, M[15], 0x49b40821, 22)
+
+	MD5_STEP(MD5_F2, a, b, c, d, M[1], 0xf61e2562, 5)
+	MD5_STEP(MD5_F2, d, a, b, c, M[6], 0xc040b340, 9)
+	MD5_STEP(MD5_F2, c, d, a, b, M[11], 0x265e5a51, 14)
+	MD5_STEP(MD5_F2, b, c, d, a, M[0], 0xe9b6c7aa, 20)
+	MD5_STEP(MD5_F2, a, b, c, d, M[5], 0xd62f105d, 5)
+	MD5_STEP(MD5_F2, d, a, b, c, M[10], 0x02441453, 9)
+	MD5_STEP(MD5_F2, c, d, a, b, M[15], 0xd8a1e681, 14)
+	MD5_STEP(MD5_F2, b, c, d, a, M[4], 0xe7d3fbc8, 20)
+	MD5_STEP(MD5_F2, a, b, c, d, M[9], 0x21e1cde6, 5)
+	MD5_STEP(MD5_F2, d, a, b, c, M[14], 0xc33707d6, 9)
+	MD5_STEP(MD5_F2, c, d, a, b, M[3], 0xf4d50d87, 14)
+	MD5_STEP(MD5_F2, b, c, d, a, M[8], 0x455a14ed, 20)
+	MD5_STEP(MD5_F2, a, b, c, d, M[13], 0xa9e3e905, 5)
+	MD5_STEP(MD5_F2, d, a, b, c, M[2], 0xfcefa3f8, 9)
+	MD5_STEP(MD5_F2, c, d, a, b, M[7], 0x676f02d9, 14)
+	MD5_STEP(MD5_F2, b, c, d, a, M[12], 0x8d2a4c8a, 20)
+
+	MD5_STEP(MD5_F3, a, b, c, d, M[5], 0xfffa3942, 4)
+	MD5_STEP(MD5_F3, d, a, b, c, M[8], 0x8771f681, 11)
+	MD5_STEP(MD5_F3, c, d, a, b, M[11], 0x6d9d6122, 16)
+	MD5_STEP(MD5_F3, b, c, d, a, M[14], 0xfde5380c, 23)
+	MD5_STEP(MD5_F3, a, b, c, d, M[1], 0xa4beea44, 4)
+	MD5_STEP(MD5_F3, d, a, b, c, M[4], 0x4bdecfa9, 11)
+	MD5_STEP(MD5_F3, c, d, a, b, M[7], 0xf6bb4b60, 16)
+	MD5_STEP(MD5_F3, b, c, d, a, M[10], 0xbebfbc70, 23)
+	MD5_STEP(MD5_F3, a, b, c, d, M[13], 0x289b7ec6, 4)
+	MD5_STEP(MD5_F3, d, a, b, c, M[0], 0xeaa127fa, 11)
+	MD5_STEP(MD5_F3, c, d, a, b, M[3], 0xd4ef3085, 16)
+	MD5_STEP(MD5_F3, b, c, d, a, M[6], 0x04881d05, 23)
+	MD5_STEP(MD5_F3, a, b, c, d, M[9], 0xd9d4d039, 4)
+	MD5_STEP(MD5_F3, d, a, b, c, M[12], 0xe6db99e5, 11)
+	MD5_STEP(MD5_F3, c, d, a, b, M[15], 0x1fa27cf8, 16)
+	MD5_STEP(MD5_F3, b, c, d, a, M[2], 0xc4ac5665, 23)
+
+	MD5_STEP(MD5_F4, a, b, c, d, M[0], 0xf4292244, 6)
+	MD5_STEP(MD5_F4, d, a, b, c, M[7], 0x432aff97, 10)
+	MD5_STEP(MD5_F4, c, d, a, b, M[14], 0xab9423a7, 15)
+	MD5_STEP(MD5_F4, b, c, d, a, M[5], 0xfc93a039, 21)
+	MD5_STEP(MD5_F4, a, b, c, d, M[12], 0x655b59c3, 6)
+	MD5_STEP(MD5_F4, d, a, b, c, M[3], 0x8f0ccc92, 10)
+	MD5_STEP(MD5_F4, c, d, a, b, M[10], 0xffeff47d, 15)
+	MD5_STEP(MD5_F4, b, c, d, a, M[1], 0x85845dd1, 21)
+	MD5_STEP(MD5_F4, a, b, c, d, M[8], 0x6fa87e4f, 6)
+	MD5_STEP(MD5_F4, d, a, b, c, M[15], 0xfe2ce6e0, 10)
+	MD5_STEP(MD5_F4, c, d, a, b, M[6], 0xa3014314, 15)
+	MD5_STEP(MD5_F4, b, c, d, a, M[13], 0x4e0811a1, 21)
+	MD5_STEP(MD5_F4, a, b, c, d, M[4], 0xf7537e82, 6)
+	MD5_STEP(MD5_F4, d, a, b, c, M[11], 0xbd3af235, 10)
+	MD5_STEP(MD5_F4, c, d, a, b, M[2], 0x2ad7d2bb, 15)
+	MD5_STEP(MD5_F4, b, c, d, a, M[9], 0xeb86d391, 21)
+
+	h[0] += a;
+	h[1] += b;
+	h[2] += c;
+	h[3] += d;
+}
+
+std::array<uint8_t, 16> md5(const uint8_t *data, size_t len) {
+	uint32_t h[4] = { MD5_INIT[0], MD5_INIT[1], MD5_INIT[2], MD5_INIT[3] };
+
+	std::vector<uint8_t> msg(data, data + len);
+	msg.push_back(0x80);
+	while (msg.size() % 64 != 56)
+		msg.push_back(0);
+	uint64_t bits = (uint64_t) len * 8;
+	for (int i = 0; i < 8; i++)
+		msg.push_back((bits >> (i * 8)) & 0xFF);
+
+	for (size_t off = 0; off < msg.size(); off += 64) {
+		uint32_t M[16];
+		for (int i = 0; i < 16; i++)
+			M[i] = rd32(&msg[off + i * 4]);
+		md5Transform(h, M);
+	}
+
+	std::array<uint8_t, 16> out;
+	for (int i = 0; i < 4; i++)
+		wr32(&out[i * 4], h[i]);
+	return out;
+}
+
+/* ---------------------------------------------------------------- MD4 --- */
+
+void md4Compress(uint32_t st[4], const uint8_t *block) {
+	uint32_t X[16];
+	for (int i = 0; i < 16; i++)
+		X[i] = rd32(block + i * 4);
+
+	uint32_t a = st[0], b = st[1], c = st[2], d = st[3];
+	static const unsigned S1[4] = { 3, 7, 11, 19 };
+	static const unsigned S2[4] = { 3, 5, 9, 13 };
+	static const unsigned S3[4] = { 3, 9, 11, 15 };
+	static const unsigned O3[16] = { 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15 };
+
+	for (unsigned i = 0; i < 16; i++) {
+		uint32_t v = a + ((b & c) | (~b & d)) + X[i];
+		a = d; d = c; c = b; b = rol32(v, S1[i % 4]);
+	}
+	for (unsigned i = 0; i < 16; i++) {
+		unsigned k = (i % 4) * 4 + i / 4;
+		uint32_t v = a + ((b & c) | (b & d) | (c & d)) + X[k] + 0x5A827999;
+		a = d; d = c; c = b; b = rol32(v, S2[i % 4]);
+	}
+	for (unsigned i = 0; i < 16; i++) {
+		uint32_t v = a + (b ^ c ^ d) + X[O3[i]] + 0x6ED9EBA1;
+		a = d; d = c; c = b; b = rol32(v, S3[i % 4]);
+	}
+
+	st[0] += a;
+	st[1] += b;
+	st[2] += c;
+	st[3] += d;
+}
+
+// MD4 of exactly 64 bytes.
+std::array<uint8_t, 16> md4Block(const uint8_t *key64) {
+	uint32_t st[4] = { 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476 };
+	md4Compress(st, key64);
+
+	uint8_t pad[64] = { 0x80 };
+	wr32(&pad[56], 512);
+	md4Compress(st, pad);
+
+	std::array<uint8_t, 16> out;
+	for (int i = 0; i < 4; i++)
+		wr32(&out[i * 4], st[i]);
+	return out;
+}
+
+/* ------------------------------------------------------- Stream cipher --- */
+
+// RC4 key schedule with MD4(key) as the key, followed by a modified PRGA with ciphertext feedback.
+void streamCipher(uint8_t *data, size_t size, const uint8_t *key64, bool encrypt) {
+	std::array<uint8_t, 16> key = md4Block(key64);
+
+	uint8_t S[256];
+	for (int i = 0; i < 256; i++)
+		S[i] = i;
+	for (int i = 0, j = 0; i < 256; i++) {
+		j = (j + key[i & 0xF] + S[i]) & 0xFF;
+		std::swap(S[i], S[j]);
+	}
+
+	uint8_t i = 0, j = 0, prev = 0;
+	for (size_t k = 0; k < size; k++) {
+		i++;
+		prev += S[i];
+		j += prev;
+		uint8_t t = S[j] + prev;
+		S[i] = S[j];
+		S[j] = prev;
+		if (encrypt) {
+			prev = S[t] ^ data[k];
+			data[k] = prev;
+		} else {
+			prev = data[k];
+			data[k] = S[t] ^ prev;
+		}
+	}
+}
+
+/* ------------------------------------------------------------ Constants --- */
+
+// 64-byte cipher key blocks embedded in PapuaUtils. Some words are replaced with ESN / SKEY / IMEI at runtime.
+const uint8_t KEY_EEP[64] = {
+	0x14, 0x0a, 0xee, 0xe5, 0xd7, 0xfb, 0xff, 0xf8, 0x76, 0x4d, 0xc6, 0x03, 0xfd, 0xb2, 0xf9, 0xb2,
+	0xb4, 0xcd, 0x66, 0xa2, 0x26, 0xf7, 0x10, 0xa4, 0x3e, 0x11, 0xc2, 0x43, 0xf4, 0x51, 0xf6, 0xaf,
+	0xdc, 0x6d, 0x98, 0x8c, 0x08, 0x8f, 0x58, 0x8e, 0xdc, 0x4f, 0xb8, 0x8e, 0x08, 0xe2, 0x28, 0x41,
+	0x00, 0x00, 0x00, 0x00, 0x55, 0x55, 0x55, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const uint8_t KEY_MK1[64] = {
+	0x00, 0x00, 0x00, 0x00, 0xee, 0xee, 0xee, 0xee, 0x0a, 0xd0, 0xdc, 0x9c, 0xaf, 0xec, 0xaa, 0xb9,
+	0x51, 0xa5, 0x7b, 0x85, 0xe0, 0x80, 0xe9, 0xb3, 0xf6, 0x7f, 0x01, 0xf8, 0x9d, 0x71, 0x8f, 0x42,
+	0x4d, 0xf5, 0xa0, 0xe1, 0xd2, 0x1e, 0xd2, 0x4f, 0xdc, 0x6d, 0x98, 0x8c, 0x08, 0x8f, 0x58, 0x8e,
+	0xdc, 0x4f, 0xb8, 0x8e, 0x08, 0xe2, 0x28, 0x08, 0x1a, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x54,
+};
+const uint8_t KEY_MK2[64] = {
+	0x08, 0x1a, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0xd8, 0xc5, 0x72, 0x7c, 0x25, 0xf8, 0xc8, 0x59,
+	0xdb, 0xee, 0x22, 0xca, 0xb5, 0x7d, 0xb4, 0xf3, 0xa5, 0x5e, 0x6e, 0xb1, 0x0d, 0xb1, 0xa5, 0x67,
+	0xdc, 0x6d, 0x98, 0x8c, 0x08, 0x8f, 0x58, 0x8e, 0xdc, 0x4f, 0xb8, 0x8e, 0x08, 0xe2, 0x28, 0x41,
+	0x16, 0xea, 0xfa, 0xf7, 0xd7, 0xc4, 0xd9, 0x2a, 0x3b, 0xf2, 0x0b, 0x7f, 0xee, 0xee, 0xee, 0xee,
+};
+
+// Nibble substitution boxes and round keys of the IMEI block cipher (EEPROM blocks 76 and 9).
+const uint8_t SBOX_HI[16] = { 0x03, 0x0f, 0x01, 0x0d, 0x05, 0x0b, 0x0d, 0x09, 0x0d, 0x07, 0x06, 0x00, 0x0e, 0x06, 0x0b, 0x08 };
+const uint8_t SBOX_LO[16] = { 0x0a, 0x0e, 0x01, 0x05, 0x03, 0x06, 0x02, 0x0f, 0x0b, 0x0a, 0x03, 0x05, 0x06, 0x05, 0x04, 0x02 };
+const uint8_t FEISTEL_KEY[8] = { 0xe3, 0xb7, 0x5c, 0x13, 0xb0, 0xd2, 0xc4, 0x19 };
+
+// Constant tail of EEPROM block 52 (after BKEY and the VerDown byte); the rest is 0xFF.
+const uint8_t BLOCK52_TAIL[145] = {
+	0xff, 0x01, 0x00, 0x00, 0x01, 0x03, 0x00, 0x01, 0x00, 0x01, 0x00, 0x54, 0x00, 0x55, 0x00, 0x80,
+	0x00, 0xd9, 0xd9, 0xf3, 0xbb, 0x3f, 0x70, 0x85, 0x83, 0x86, 0x91, 0xd8, 0xa0, 0xda, 0xc3, 0x95,
+	0xa5, 0xa3, 0x4d, 0xd0, 0x4f, 0xcf, 0xe3, 0x50, 0x4a, 0x54, 0xa6, 0x34, 0x52, 0x60, 0x34, 0xd2,
+	0xfb, 0x76, 0x69, 0x5d, 0xef, 0x36, 0x96, 0x56, 0x0f, 0xc0, 0x6d, 0xef, 0x38, 0x12, 0xb7, 0xc7,
+	0x2f, 0xbf, 0xd6, 0xa0, 0xd5, 0x15, 0xe7, 0x13, 0x24, 0x14, 0x45, 0x40, 0x40, 0xf9, 0x69, 0x49,
+	0x08, 0xb1, 0x3b, 0xed, 0x97, 0x9a, 0xef, 0x9f, 0x20, 0x63, 0xda, 0x07, 0xf8, 0x40, 0x3c, 0xeb,
+	0x30, 0x32, 0x68, 0x08, 0x49, 0x86, 0xa2, 0x3b, 0x3e, 0x61, 0x21, 0xfe, 0x7b, 0xce, 0xd2, 0xad,
+	0x3b, 0x02, 0x00, 0x5c, 0x41, 0x30, 0xa3, 0x8d, 0x52, 0x79, 0xf0, 0x97, 0x28, 0x4e, 0xfc, 0x18,
+	0x6a, 0xe9, 0x5e, 0x0a, 0xb2, 0xbe, 0x4b, 0xa7, 0xa8, 0x58, 0x44, 0x28, 0x91, 0xf4, 0xbe, 0xec,
+	0xef,
+};
+
+/* ------------------------------------------------------ Block builders --- */
+
+// IMEI packed into 8 bytes: 0x?A, then digit pairs (high nibble = even digit).
+std::array<uint8_t, 8> packImei8(const std::string &imei) {
+	std::array<uint8_t, 8> out{};
+	auto digit = [&](size_t i) { return (uint8_t) (imei[i] - '0'); };
+	out[0] = 0x0A | (digit(0) << 4);
+	for (size_t k = 1; k < 8; k++)
+		out[k] = digit(2 * k - 1) | (k < 7 ? (digit(2 * k) << 4) : 0);
+	return out;
+}
+
+uint8_t luhnCheckDigit(const std::string &imei) {
+	unsigned sum = 0;
+	for (size_t i = 0; i < 14; i++) {
+		unsigned d = (unsigned) (imei[i] - '0') << (i & 1);
+		sum += d / 10 + d % 10;
+	}
+	return (10 - sum % 10) % 10;
+}
+
+void feistelRound(uint8_t *buf, uint8_t roundKey) {
+	uint8_t mask = 0;
+	for (int k = 0; k < 5; k++) {
+		uint8_t old = buf[k];
+		uint8_t a = (SBOX_HI[old >> 4] << 4) + SBOX_LO[old & 0xF];
+		buf[k] = a ^ roundKey ^ buf[k + 5] ^ mask;
+		buf[k + 5] = old;
+		mask ^= 0xFF;
+	}
+}
+
+// EEPROM LITE block 76 (variant 0) and FULL block 9 (variant 1).
+std::vector<uint8_t> buildImeiBlock(const std::string &imei, int variant) {
+	std::vector<uint8_t> buf(10, 0);
+	for (size_t i = 0; i < 14; i++) {
+		uint8_t d = imei[i] - '0';
+		if (i & 1)
+			buf[i / 2] |= d << 4;
+		else
+			buf[i / 2] = d;
+	}
+	buf[7] = luhnCheckDigit(imei) << 4;
+
+	uint8_t xorEven = 0, xorOdd = 0;
+	for (int i = 0; i < 8; i++)
+		(i & 1 ? xorOdd : xorEven) ^= buf[i];
+	buf[8] = variant ? xorOdd : xorEven;
+	buf[9] = xorOdd ^ xorEven ^ 0xFF;
+
+	for (int r = variant ? 0 : 1; r < 8; r += 2)
+		feistelRound(buf.data(), FEISTEL_KEY[r]);
+	return buf;
+}
+
+void appendChecksum(uint8_t *buf, size_t off, size_t n) {
+	uint8_t sum = 0, x = 0;
+	for (size_t i = 0; i < n; i++) {
+		sum += buf[off + i];
+		x ^= buf[off + i];
+	}
+	buf[off + n] = sum;
+	buf[off + n + 1] = x;
+}
+
+std::array<uint8_t, 64> keyEeprom(uint32_t esn, const std::string &imei) {
+	std::array<uint8_t, 64> key;
+	memcpy(key.data(), KEY_EEP, 64);
+	wr32(&key[0x30], esn);
+	std::array<uint8_t, 8> imei8 = packImei8(imei);
+	memcpy(&key[0x38], imei8.data(), 8);
+	return key;
+}
+
+// EEPROM FULL block 8
+std::vector<uint8_t> buildBlock5008(const std::string &imei, uint32_t esn) {
+	std::vector<uint8_t> buf(0xE0, 0);
+	static const uint32_t head[10] = { 0x56605650, 0, 0x300, 0x670000, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0x6462FF00, 0x56805670, 0 };
+	for (int i = 0; i < 10; i++)
+		wr32(&buf[i * 4], head[i]);
+	memset(&buf[0x28], 0xFF, 0xB8);
+	wr32(&buf[0xD8], 0x50);
+	wr32(&buf[0xDC], 0);
+	appendChecksum(buf.data(), 8, 0x16);
+	appendChecksum(buf.data(), 0x28, 0xB0);
+	wr32(&buf[0x00], rd32(&buf[0x00]) ^ 0xBA1FE5D7);
+	wr32(&buf[0x04], rd32(&buf[0x04]) ^ 0xD95D2DFD);
+	wr32(&buf[0x20], rd32(&buf[0x20]) ^ 0xBA1FE5D7);
+	wr32(&buf[0x24], rd32(&buf[0x24]) ^ 0xD95D2DFD);
+	std::array<uint8_t, 64> key = keyEeprom(esn, imei);
+	streamCipher(&buf[0], 0x20, key.data(), true);
+	streamCipher(&buf[0x20], 0xC0, key.data(), true);
+	return buf;
+}
+
+// EEPROM FULL block 77
+std::vector<uint8_t> buildBlock5077(const std::string &imei, uint32_t esn) {
+	std::vector<uint8_t> buf(0xE8, 0xFF);
+	wr32(&buf[0], 0x56A05690);
+	wr32(&buf[4], 0);
+	buf[0xB] = 0;
+	wr32(&buf[0xE0], 0x063DFF29);
+	wr32(&buf[0xE4], 0xF3800B06);
+	appendChecksum(buf.data(), 8, 0xD8);
+	wr32(&buf[0], rd32(&buf[0]) ^ 0xBA1FE5D7);
+	wr32(&buf[4], rd32(&buf[4]) ^ 0xD95D2DFD);
+	std::array<uint8_t, 64> key = keyEeprom(esn, imei);
+	streamCipher(buf.data(), buf.size(), key.data(), true);
+	return buf;
+}
+
+// EEPROM FULL block 121: encrypted SKEY marker + 6 encrypted master codes
+std::vector<uint8_t> buildBlock5121(const SiemensKeys &keys) {
+	std::array<uint8_t, 8> imei8 = packImei8(keys.imei);
+
+	auto key1 = [&](uint32_t code) {
+		std::array<uint8_t, 64> key;
+		memcpy(key.data(), KEY_MK1, 64);
+		wr32(&key[0], code ^ 0x7F0BF23B);
+		wr32(&key[4], keys.esn);
+		memcpy(&key[0x38], imei8.data(), 8);
+		return key;
+	};
+	auto key2 = [&](uint32_t code) {
+		std::array<uint8_t, 64> key;
+		memcpy(key.data(), KEY_MK2, 64);
+		wr32(&key[0], ((uint32_t) imei8[0] << 8) + 8 + ((uint32_t) imei8[1] << 16) + ((uint32_t) imei8[2] << 24));
+		memcpy(&key[4], &imei8[3], 4);
+		wr32(&key[0x38], code ^ 0x7F0BF23B);
+		wr32(&key[0x3C], keys.esn);
+		return key;
+	};
+
+	std::vector<uint8_t> out(8 + 6 * 8);
+	wr32(&out[0], 0x77C5742D);
+	wr32(&out[4], 0xF49A4ADA);
+	streamCipher(&out[0], 8, key1(keys.skey).data(), true);
+
+	for (uint32_t k = 0; k < 6; k++) {
+		uint8_t *entry = &out[8 + k * 8];
+		wr32(entry, k ^ 0x77C5742D);
+		wr32(entry + 4, 0xF49A4ADA);
+		streamCipher(entry, 8, key2(keys.masterKeys[k]).data(), true);
+		streamCipher(entry, 8, key1(keys.masterKeys[k]).data(), true);
+	}
+	return out;
+}
+
+// EEPROM FULL block 122
+std::vector<uint8_t> buildBlock5122(uint32_t skey) {
+	std::vector<uint8_t> out(6);
+	wr32(&out[0], skey);
+	out[4] = 0x58;
+	out[5] = 0;
+	return out;
+}
+
+// EEPROM FULL block 123 (short 12-byte variant used by x75/x85 firmware)
+std::vector<uint8_t> buildBlock5123(const std::vector<uint8_t> &block5121, bool shortVariant) {
+	std::vector<uint8_t> out(shortVariant ? 0xC : 0x20, 0);
+	wr32(&out[0], shortVariant ? 0xFFFFFF3F : 0xFFFF1F07);
+	memcpy(&out[4], block5121.data(), 8);
+	return out;
+}
+
+// EEPROM LITE block 52
+std::vector<uint8_t> buildBlock52(const std::array<uint8_t, 16> &bootKey, uint8_t verDown) {
+	std::vector<uint8_t> out(0x122, 0xFF);
+	memcpy(&out[0], bootKey.data(), 16);
+	out[16] = verDown;
+	memcpy(&out[17], BLOCK52_TAIL, sizeof(BLOCK52_TAIL));
+	return out;
+}
+
+// EEPROM FULL block 468 (x85 only)
+std::vector<uint8_t> buildBlock5468(const SiemensKeys &keys, const std::array<uint8_t, 16> &bootKey) {
+	std::vector<uint8_t> out(0x31);
+	memcpy(&out[0], bootKey.data(), 16);
+	out[16] = 0x58;
+	uint8_t esn[4];
+	wr32(esn, keys.esn);
+	std::array<uint8_t, 16> esnHash = md5(esn, 4);
+	memcpy(&out[0x11], esnHash.data(), 16);
+	std::array<uint8_t, 16> imeiHash = md5((const uint8_t *) keys.imei.data(), keys.imei.size());
+	memcpy(&out[0x21], imeiHash.data(), 8);
+	std::array<uint8_t, 16> totalHash = md5(out.data(), 0x29);
+	memcpy(&out[0x29], totalHash.data(), 8);
+	return out;
+}
+
+/* --------------------------------------------------------- Patching --- */
+
+struct EepromEntry {
+	uint32_t flags;
+	uint32_t id;
+	uint32_t size;
+	uint32_t dataOffset;
+};
+
+bool readEntry(const uint8_t *hdr, EepromEntry &e) {
+	e.flags = rd32(hdr);
+	e.id = rd16(hdr + 4);
+	e.size = rd32(hdr + 8);
+	e.dataOffset = rd32(hdr + 12);
+	return (e.flags == 0xFFFFFFC0 || e.flags == 0xFFFFFF00) && hdr[6] == 0 && e.id < 500 && e.size < 25000;
+}
+
+bool replaceBytes(std::vector<uint8_t> &data, const std::vector<size_t> &positions, const std::vector<uint8_t> &value) {
+	bool changed = false;
+	for (size_t i = 0; i < value.size(); i++) {
+		if (data[positions[i]] != value[i]) {
+			data[positions[i]] = value[i];
+			changed = true;
+		}
+	}
+	return changed;
+}
+
+struct Generated {
+	std::vector<uint8_t> data;
+	uint32_t bit;
+};
+
+struct FlashLayout {
+	bool x85 = false;
+	size_t blockSize = 0;
+	size_t signatureOffset = 0;
+	size_t hashOffset = 0;    // bootcore HASH
+	size_t imeiOffset = 0;    // bootcore IMEI string
+};
+
+bool detectLayout(const std::vector<uint8_t> &ff, FlashLayout &layout) {
+	if (ff.size() < 0x100000)
+		return false;
+
+	layout.x85 = memcmp(&ff[0x1200], "\x00\x03LS", 4) == 0;
+	layout.blockSize = layout.x85 ? 0x40000 : 0x20000;
+	layout.signatureOffset = layout.x85 ? 0x3FFE0 : 0;
+	if (ff.size() % layout.blockSize != 0)
+		return false;
+
+	if (layout.x85) {
+		layout.hashOffset = 0x3E400;
+		layout.imeiOffset = 0x3E410;
+	} else if (ff[0x200] == 2) {
+		layout.hashOffset = 0x23C;
+		layout.imeiOffset = 0x660;
+	} else {
+		layout.hashOffset = 0x238;
+		layout.imeiOffset = 0x65C;
+	}
+	return true;
+}
+
+bool isBlank(const std::array<uint8_t, 16> &data) {
+	for (uint8_t byte : data) {
+		if (byte != 0xFF)
+			return false;
+	}
+	return true;
+}
+
+// Calls fn(id, positions) for every valid EEPROM entry, where positions are the absolute
+// offsets of the entry payload. FULL block ids are reported as id + 5000.
+void walkEeprom(const std::vector<uint8_t> &ff, const FlashLayout &layout,
+	const std::function<void(uint32_t, const std::vector<size_t> &)> &fn)
+{
+	for (size_t base = 0; base < ff.size(); base += layout.blockSize) {
+		const uint8_t *signature = &ff[base + layout.signatureOffset];
+		bool full;
+		if (memcmp(signature, "EEFU", 4) == 0) {
+			full = true;
+		} else if (memcmp(signature, "EELI", 4) == 0) {
+			full = false;
+		} else {
+			continue;
+		}
+
+		const size_t stride = layout.x85 ? 0x20 : 0x10;
+		const uint32_t idBase = full ? 5000 : 0;
+		const size_t leadingBytes = full ? 1 : 0;                     // FULL payloads carry one extra byte in front
+		const size_t sizeExtra = (full ? 1 : 0) | (layout.x85 ? 0 : 1); // stored size = payload + sizeExtra
+
+		size_t hdr = layout.x85 ? 0x3FFC0 : 0x1FFF0;
+		while (hdr > 0x2000) {
+			EepromEntry entry;
+			bool valid = readEntry(&ff[base + hdr], entry);
+			size_t next = hdr - stride;
+			if (entry.flags == 0xFFFFFFFF)
+				break;
+
+			if (valid && layout.x85) {
+				// Headers are not always contiguous on x85: find the next valid one.
+				while (next > 0x2000) {
+					EepromEntry probe;
+					if (readEntry(&ff[base + next], probe))
+						break;
+					next -= stride;
+					if (hdr - next > 0x420) {
+						next = 0x200;
+						break;
+					}
+				}
+			}
+
+			if (valid && entry.flags == 0xFFFFFFC0 && entry.size > sizeExtra) {
+				const size_t payload = entry.size - sizeExtra;
+				std::vector<size_t> positions;
+				const bool inlineData = layout.x85 &&
+					((full && entry.size <= 0x200) || (!full && entry.size <= 0x10));
+				if (inlineData) {
+					// Small x85 entries are stored right below the header, in 16-byte pieces every 32 bytes.
+					size_t start = hdr - 0x10 - entry.size - (entry.size & ~0xFu);
+					for (size_t i = start; i < hdr; i++) {
+						if (!(i & 0x10))
+							positions.push_back(base + i);
+					}
+					if (positions.size() >= leadingBytes + payload) {
+						positions.erase(positions.begin(), positions.begin() + leadingBytes);
+						positions.resize(payload);
+						fn(entry.id + idBase, positions);
+					}
+				} else if ((size_t) entry.dataOffset + entry.size < layout.blockSize) {
+					positions.reserve(payload);
+					for (size_t i = 0; i < payload; i++)
+						positions.push_back(base + entry.dataOffset + leadingBytes + i);
+					fn(entry.id + idBase, positions);
+				}
+			}
+			hdr = next;
+		}
+	}
+}
+
+} // namespace
+
+std::string toHex(const uint8_t *data, size_t size) {
+	static const char digits[] = "0123456789ABCDEF";
+	std::string s;
+	for (size_t i = 0; i < size; i++) {
+		s += digits[data[i] >> 4];
+		s += digits[data[i] & 0xF];
+	}
+	return s;
+}
+
+void siemensCalcKeys(uint32_t esn, uint32_t skey, std::array<uint8_t, 16> &bootKey, std::array<uint8_t, 16> &hash) {
+	uint8_t block[16];
+	wr32(&block[0], esn);
+	wr32(&block[4], skey);
+	for (int i = 0; i < 8; i++)
+		block[8 + i] = block[i] ^ block[i + 3];
+	bootKey = md5(block, 16);
+	hash = md5(bootKey.data(), 16);
+}
+
+SiemensRecalcResult siemensRecalcFullflash(std::vector<uint8_t> &ff, const SiemensKeys &keys) {
+	SiemensRecalcResult result;
+
+	FlashLayout layout;
+	if (!detectLayout(ff, layout)) {
+		result.log.push_back("fullflash size or layout was not recognized");
+		return result;
+	}
+
+	std::array<uint8_t, 16> bootKey, hash;
+	siemensCalcKeys(keys.esn, keys.skey, bootKey, hash);
+
+	// Bootcore: HASH + IMEI string
+	const size_t hashOffset = layout.hashOffset;
+	const size_t imeiOffset = layout.imeiOffset;
+	if (rd32(&ff[hashOffset]) == 0xFFFFFFFF) {
+		result.log.push_back("BCORE is erased, recalculation is not possible");
+		return result;
+	}
+	result.structureOk = true;
+
+	if (memcmp(&ff[hashOffset], hash.data(), 16) != 0) {
+		memcpy(&ff[hashOffset], hash.data(), 16);
+		result.log.push_back("BCORE: HASH replaced with " + toHex(hash.data(), 16));
+		result.replaced++;
+	}
+	if (memcmp(&ff[imeiOffset], keys.imei.data(), 15) != 0) {
+		memcpy(&ff[imeiOffset], keys.imei.data(), 15);
+		result.log.push_back("BCORE: IMEI replaced with " + keys.imei);
+		result.replaced++;
+	}
+
+	// EEPROM blocks. IDs >= 5000 live in EEFULL (ID - 5000), the others in EELITE.
+	std::vector<uint8_t> block5121 = buildBlock5121(keys);
+	std::map<uint32_t, Generated> generated = {
+		{ 76,   { buildImeiBlock(keys.imei, 0), 0x001 } },
+		{ 5008, { buildBlock5008(keys.imei, keys.esn), 0x002 } },
+		{ 5009, { buildImeiBlock(keys.imei, 1), 0x004 } },
+		{ 5077, { buildBlock5077(keys.imei, keys.esn), 0x008 } },
+		{ 5121, { block5121, 0x010 } },
+		{ 5122, { buildBlock5122(keys.skey), 0x020 } },
+		{ 5123, { {}, 0x040 } },
+		{ 52,   { buildBlock52(bootKey, keys.verDown), 0x080 } },
+		{ 5468, { buildBlock5468(keys, bootKey), 0x100 } },
+		{ 320,  { std::vector<uint8_t>(bootKey.begin(), bootKey.end()), 0x200 } },
+	};
+	const uint32_t mandatoryMask = 0xFF;
+	uint32_t foundMask = 0;
+
+	walkEeprom(ff, layout, [&](uint32_t id, const std::vector<size_t> &positions) {
+		auto it = generated.find(id);
+		if (it == generated.end())
+			return;
+
+		std::vector<uint8_t> value = it->second.data;
+		if (id == 5123)
+			value = buildBlock5123(block5121, positions.size() == 0xC);
+		foundMask |= it->second.bit;
+
+		if (positions.size() != value.size()) {
+			result.log.push_back("EEPROM: block " + std::to_string(id) + " has unexpected size " +
+				std::to_string(positions.size()) + ", not replaced");
+			return;
+		}
+
+		if (replaceBytes(ff, positions, value)) {
+			result.log.push_back("EEPROM: block " + std::to_string(id) + " replaced");
+			result.replaced++;
+		}
+	});
+
+	result.complete = (foundMask & mandatoryMask) == mandatoryMask;
+	if (!result.complete)
+		result.log.push_back("EEPROM: not all confidential blocks were found (mask " + std::to_string(foundMask) + ")");
+	return result;
+}
+
+SiemensIdentity siemensReadIdentity(const std::vector<uint8_t> &ff) {
+	SiemensIdentity identity;
+
+	FlashLayout layout;
+	if (!detectLayout(ff, layout))
+		return identity;
+
+	const char *imei = (const char *) &ff[layout.imeiOffset];
+	for (int i = 0; i < 15; i++) {
+		if (imei[i] < '0' || imei[i] > '9')
+			return identity;
+	}
+	identity.imei.assign(imei, 15);
+	memcpy(identity.hash.data(), &ff[layout.hashOffset], 16);
+
+	bool haveSkey = false;
+	walkEeprom(ff, layout, [&](uint32_t id, const std::vector<size_t> &positions) {
+		if (id == 5122 && positions.size() >= 4) {
+			uint8_t raw[4];
+			for (int i = 0; i < 4; i++)
+				raw[i] = ff[positions[i]];
+			identity.skey = rd32(raw);
+			haveSkey = true;
+		} else if (id == 52 && positions.size() >= 16) {
+			for (int i = 0; i < 16; i++)
+				identity.bootKey[i] = ff[positions[i]];
+			identity.hasBootKey = true;
+		}
+	});
+
+	identity.ok = haveSkey && (!isBlank(identity.hash) || (identity.hasBootKey && !isBlank(identity.bootKey)));
+	return identity;
+}
+
+bool siemensRecoverEsn(const SiemensIdentity &identity, uint32_t &esn, unsigned threadCount) {
+	if (!identity.ok)
+		return false;
+
+	// One MD5 per candidate when the BootKey is known, two when only the bootcore HASH is.
+	const bool useBootKey = identity.hasBootKey && !isBlank(identity.bootKey);
+	const std::array<uint8_t, 16> &wanted = useBootKey ? identity.bootKey : identity.hash;
+	uint32_t target[4];
+	for (int i = 0; i < 4; i++)
+		target[i] = rd32(wanted.data() + i * 4);
+
+	if (!threadCount)
+		threadCount = std::max(1u, std::thread::hardware_concurrency());
+
+	const uint32_t skey = identity.skey;
+	std::atomic<bool> found(false);
+	std::atomic<uint32_t> result(0);
+
+	std::vector<std::thread> workers;
+	workers.reserve(threadCount);
+	for (unsigned t = 0; t < threadCount; t++) {
+		workers.emplace_back([&, t]() {
+			// Both hashed messages are 16 bytes, so the padding words never change.
+			uint32_t X[16] = {};
+			uint32_t Y[16] = {};
+			X[4] = Y[4] = 0x80;
+			X[14] = Y[14] = 128;
+
+			uint32_t ticks = 0;
+			for (uint64_t candidate = t; candidate < 0x100000000ULL; candidate += threadCount) {
+				if (++ticks >= 0x40000) {
+					ticks = 0;
+					if (found.load(std::memory_order_relaxed))
+						return;
+				}
+
+				// The key block is ESN, SKEY and eight bytes derived from both (see siemensCalcKeys).
+				const uint32_t value = (uint32_t) candidate;
+				X[0] = value;
+				X[1] = skey;
+				X[2] = value ^ (value >> 24) ^ (skey << 8);
+				X[3] = skey ^ (skey >> 24) ^ (X[2] << 8);
+
+				uint32_t h[4] = { MD5_INIT[0], MD5_INIT[1], MD5_INIT[2], MD5_INIT[3] };
+				md5Transform(h, X);
+				if (!useBootKey) {
+					Y[0] = h[0];
+					Y[1] = h[1];
+					Y[2] = h[2];
+					Y[3] = h[3];
+					h[0] = MD5_INIT[0];
+					h[1] = MD5_INIT[1];
+					h[2] = MD5_INIT[2];
+					h[3] = MD5_INIT[3];
+					md5Transform(h, Y);
+				}
+
+				if (h[0] == target[0] && h[1] == target[1] && h[2] == target[2] && h[3] == target[3]) {
+					result.store(value, std::memory_order_relaxed);
+					found.store(true, std::memory_order_release);
+					return;
+				}
+			}
+		});
+	}
+	for (std::thread &worker : workers)
+		worker.join();
+
+	if (!found.load(std::memory_order_acquire))
+		return false;
+
+	// Confirm the hit with the plain implementation before trusting it.
+	const uint32_t candidate = result.load(std::memory_order_relaxed);
+	std::array<uint8_t, 16> bootKey, hash;
+	siemensCalcKeys(candidate, skey, bootKey, hash);
+	if ((useBootKey ? bootKey : hash) != wanted)
+		return false;
+
+	esn = candidate;
+	return true;
+}

--- a/src/siemens_recalc.h
+++ b/src/siemens_recalc.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/*
+ * In-memory "recalculation" of a Siemens x65/x75/x85 fullflash for a given
+ * IMEI / ESN / SKEY, equivalent to "Recalc Fullflash" in x65PapuaUtils.
+ * See docs/recalc-alogrithm.md for the description of the algorithm.
+ */
+
+struct SiemensKeys {
+	std::string imei;                       // 15 decimal digits
+	uint32_t esn = 0;                       // NOR flash ESN
+	uint32_t skey = 0;                      // service key (decimal in the UI)
+	std::array<uint32_t, 6> masterKeys{};   // master codes stored in EEPROM block 121
+	uint8_t verDown = 1;                    // PapuaUtils "VerDown" value stored in EEPROM block 52
+};
+
+struct SiemensRecalcResult {
+	bool structureOk = false;   // fullflash layout was recognized
+	bool complete = false;      // every mandatory EEPROM block was found
+	size_t replaced = 0;        // number of items that had to be rewritten
+	std::vector<std::string> log;
+};
+
+// Identity a fullflash carries: everything the key check needs except the ESN.
+struct SiemensIdentity {
+	bool ok = false;                      // IMEI and usable keys were found
+	std::string imei;                     // bootcore
+	uint32_t skey = 0;                    // EEPROM FULL block 122
+	bool hasBootKey = false;
+	std::array<uint8_t, 16> bootKey{};    // EEPROM LITE block 52
+	std::array<uint8_t, 16> hash{};       // bootcore
+};
+
+// Reads the IMEI, SKEY and keys stored in the fullflash.
+SiemensIdentity siemensReadIdentity(const std::vector<uint8_t> &fullflash);
+
+// Brute forces the ESN the stored keys were derived from. Sweeps the whole 32-bit
+// space, so it takes a while. threads = 0 uses every core.
+bool siemensRecoverEsn(const SiemensIdentity &identity, uint32_t &esn, unsigned threads = 0);
+
+// BootKey (BKEY) and HASH derived from ESN and SKEY.
+void siemensCalcKeys(uint32_t esn, uint32_t skey, std::array<uint8_t, 16> &bootKey, std::array<uint8_t, 16> &hash);
+
+// Patches fullflash in place. Nothing is modified when the image already contains the right keys.
+SiemensRecalcResult siemensRecalcFullflash(std::vector<uint8_t> &fullflash, const SiemensKeys &keys);
+
+std::string toHex(const uint8_t *data, size_t size);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,8 +1,12 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
+#include <cstring>
+#include <fstream>
 #include <numeric>
+#include <random>
 #include <stdexcept>
 
 #ifdef _WIN32
@@ -23,6 +27,10 @@
 #else
 #include <spawn.h>
 #include <sys/wait.h>
+#endif
+
+#ifdef __linux__
+#include <sys/mman.h>
 #endif
 
 #if defined(__APPLE__) || defined(__MACH__)
@@ -146,4 +154,132 @@ std::string convertESNtoOTP(const std::string &esn) {
 	}
 
 	return "0200" + otpEsn + "00000000";
+}
+
+std::string esnToHex(uint32_t esn) {
+	const char hex[] = "0123456789ABCDEF";
+	std::string out;
+	for (int shift = 28; shift >= 0; shift -= 4)
+		out += hex[(esn >> shift) & 0xF];
+	return out;
+}
+
+std::string esnCachePath(const std::string &fullflash) {
+	return fullflash + ".esn";
+}
+
+bool readEsnCache(const std::string &fullflash, const std::string &imei, const std::string &key, uint32_t &esn) {
+	std::ifstream in(esnCachePath(fullflash));
+	if (!in)
+		return false;
+
+	std::string line, cachedImei, cachedKey, value;
+	while (std::getline(in, line)) {
+		if (line.starts_with("IMEI="))
+			cachedImei = line.substr(5);
+		else if (line.starts_with("KEY="))
+			cachedKey = line.substr(4);
+		else if (line.starts_with("ESN="))
+			value = line.substr(4);
+	}
+
+	const bool valid = value.size() == 8 && std::all_of(value.begin(), value.end(), [](uint8_t c) { return std::isxdigit(c); });
+	if (!valid || cachedImei != imei || cachedKey != key)
+		return false;
+
+	esn = static_cast<uint32_t>(std::stoul(value, nullptr, 16));
+	return true;
+}
+
+// Caching is best effort: a read-only directory just means the search runs again next time.
+void writeEsnCache(const std::string &fullflash, const std::string &imei, const std::string &key, uint32_t esn) {
+	std::ofstream out(esnCachePath(fullflash), std::ios::trunc);
+	if (!out)
+		return;
+	out << "# ESN recovered by pmb887x-emu, delete this file to search again\n"
+		<< "IMEI=" << imei << "\n"
+		<< "KEY=" << key << "\n"
+		<< "ESN=" << esnToHex(esn) << "\n";
+}
+
+bool readFile(const std::string &path, std::vector<uint8_t> &data) {
+	std::ifstream in(path, std::ios::binary | std::ios::ate);
+	if (!in)
+		return false;
+	std::streamsize size = in.tellg();
+	if (size < 0)
+		return false;
+	data.resize(static_cast<size_t>(size));
+	in.seekg(0);
+	return static_cast<bool>(in.read(reinterpret_cast<char *>(data.data()), size));
+}
+
+bool writeFile(const std::string &path, const std::vector<uint8_t> &data) {
+	std::ofstream out(path, std::ios::binary | std::ios::trunc);
+	if (!out)
+		return false;
+	return static_cast<bool>(out.write(reinterpret_cast<const char *>(data.data()), static_cast<std::streamsize>(data.size())));
+}
+
+TempFileCopy::~TempFileCopy() {
+#ifdef __linux__
+	if (fd >= 0)
+		close(fd);
+#endif
+	if (isTempFile) {
+		std::error_code ec;
+		std::filesystem::remove(filePath, ec);
+	}
+}
+
+bool TempFileCopy::create(const std::vector<uint8_t> &data) {
+#ifdef __linux__
+	// The descriptor is inherited by QEMU, which opens it again through /dev/fd.
+	fd = memfd_create("pmb887x-emu", 0);
+	if (fd >= 0) {
+		size_t done = 0;
+		while (done < data.size()) {
+			ssize_t written = write(fd, data.data() + done, data.size() - done);
+			if (written <= 0) {
+				close(fd);
+				fd = -1;
+				break;
+			}
+			done += static_cast<size_t>(written);
+		}
+		if (fd >= 0) {
+			filePath = "/dev/fd/" + std::to_string(fd);
+			return true;
+		}
+	}
+#endif
+
+	std::random_device rd;
+	std::error_code ec;
+	std::filesystem::path dir = std::filesystem::temp_directory_path(ec);
+	if (ec)
+		return false;
+	filePath = (dir / ("pmb887x-emu-" + std::to_string(rd()) + ".bin")).string();
+	if (!writeFile(filePath, data))
+		return false;
+	isTempFile = true;
+	return true;
+}
+
+// Writes back only the 4 KB chunks that differ from the original content.
+bool patchFile(const std::string &path, const std::vector<uint8_t> &original, const std::vector<uint8_t> &data) {
+	constexpr size_t chunk = 4096;
+	std::fstream out(path, std::ios::binary | std::ios::in | std::ios::out);
+	if (!out || original.size() != data.size())
+		return false;
+	for (size_t offset = 0; offset < data.size(); offset += chunk) {
+		size_t size = std::min(chunk, data.size() - offset);
+		if (memcmp(&original[offset], &data[offset], size) == 0)
+			continue;
+		out.seekp(static_cast<std::streamoff>(offset));
+		if (!out.write(reinterpret_cast<const char *>(&data[offset]), static_cast<std::streamsize>(size)))
+			return false;
+	}
+	out.flush();
+	return static_cast<bool>(out);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -31,3 +32,26 @@ std::string convertESNtoOTP(const std::string &esn);
 std::string convertIMEItoOTP(const std::string &imei);
 int exec(const std::vector<std::string> &argv);
 std::string strJoin(const std::vector<std::string> &vec, const std::string &delimiter = "");
+
+std::string esnToHex(uint32_t esn);
+std::string esnCachePath(const std::string &fullflash);
+bool readEsnCache(const std::string &fullflash, const std::string &imei, const std::string &key, uint32_t &esn);
+void writeEsnCache(const std::string &fullflash, const std::string &imei, const std::string &key, uint32_t esn);
+
+bool readFile(const std::string &path, std::vector<uint8_t> &data);
+bool writeFile(const std::string &path, const std::vector<uint8_t> &data);
+bool patchFile(const std::string &path, const std::vector<uint8_t> &original, const std::vector<uint8_t> &data);
+
+// Exposes a blob to other processes as a file path: an anonymous memory file on Linux,
+// a temporary file elsewhere.
+class TempFileCopy {
+public:
+	~TempFileCopy();
+	bool create(const std::vector<uint8_t> &data);
+	const std::string &path() const { return filePath; }
+
+private:
+	int fd = -1;
+	std::string filePath;
+	bool isTempFile = false;
+};


### PR DESCRIPTION
Дефолтом делает рекальк (во временный файл если не указано --rw), так как он быстрее, но так же добавлена опция для подбора ESN. У меня они подозрительно быстро подбираются, но худший случай

На S75 работает и то и другое
На SGOLDах, кажется рекальк не работает, но поиск ESN работает. 
На Елке работает рекальк, но не подбор ESN.

В общем ещё нужно доделывать, но мне кажется, уже в таком виде полезно